### PR TITLE
fix flaky test

### DIFF
--- a/racy_test.go
+++ b/racy_test.go
@@ -67,69 +67,16 @@ func TestNoRaces(t *testing.T) {
 		arbiter.ItsAFactThat("s.Publish()")
 	})
 
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, err := c.Send(defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c.Send()")
-	})
+	// Warm up client execution paths.
+	execClientSend(ctx, wg, maxConcurrent, c, arbiter)
+	execClientSendSync(ctx, wg, maxConcurrent, c, arbiter)
+	execClientBroadcast(ctx, wg, maxConcurrent, c, arbiter)
+	execClientPublish(ctx, wg, maxConcurrent, c, arbiter)
 
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, _, err := c.SendSync(defaultCtx, defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c.SendSync()")
-	})
-
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, err := c.Broadcast(defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c.Broadcast()")
-	})
-
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, err := c.Publish("topic.a", defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c.Publish()")
-	})
-
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, err := c2.Send(defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c2.Send()")
-	})
-
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, _, err := c2.SendSync(defaultCtx, defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c2.SendSync()")
-	})
-
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, err := c2.Broadcast(defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c2.Broadcast()")
-	})
-
-	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
-		if _, err := c2.Publish("topic.a", defaultMsg); err != nil && err != client.ErrNotRunning {
-			arbiter.ErrorHappened(err)
-			return
-		}
-		arbiter.ItsAFactThat("c2.Publish()")
-	})
+	execClientSend(ctx, wg, maxConcurrent, c2, arbiter)
+	execClientSendSync(ctx, wg, maxConcurrent, c2, arbiter)
+	execClientBroadcast(ctx, wg, maxConcurrent, c2, arbiter)
+	execClientPublish(ctx, wg, maxConcurrent, c2, arbiter)
 
 	<-ctx.Done()
 
@@ -142,4 +89,44 @@ func TestNoRaces(t *testing.T) {
 	// Have minimum feedback of what happened.
 	t.Logf("Registered errors: %v", arbiter.Errors())
 	t.Logf("Registered events: %v", arbiter.EvCount())
+}
+
+func execClientSend(ctx context.Context, wg *sync.WaitGroup, maxConcurrent int, c *client.Client, arbiter *test.Arbiter) {
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, err := c.Send(defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c.Send()")
+	})
+}
+
+func execClientSendSync(ctx context.Context, wg *sync.WaitGroup, maxConcurrent int, c *client.Client, arbiter *test.Arbiter) {
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, _, err := c.SendSync(defaultCtx, defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c.SendSync()")
+	})
+}
+
+func execClientBroadcast(ctx context.Context, wg *sync.WaitGroup, maxConcurrent int, c *client.Client, arbiter *test.Arbiter) {
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, err := c.Broadcast(defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c.Broadcast()")
+	})
+}
+
+func execClientPublish(ctx context.Context, wg *sync.WaitGroup, maxConcurrent int, c *client.Client, arbiter *test.Arbiter) {
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, err := c.Publish("topic.a", defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c.Publish()")
+	})
 }

--- a/racy_test.go
+++ b/racy_test.go
@@ -84,6 +84,14 @@ func TestNoRaces(t *testing.T) {
 	})
 
 	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, err := c.Broadcast(defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c.Broadcast()")
+	})
+
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
 		if _, err := c2.Send(defaultMsg); err != nil && err != client.ErrNotRunning {
 			arbiter.ErrorHappened(err)
 			return
@@ -97,6 +105,14 @@ func TestNoRaces(t *testing.T) {
 			return
 		}
 		arbiter.ItsAFactThat("c2.SendSync()")
+	})
+
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, err := c2.Broadcast(defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c2.Broadcast()")
 	})
 
 	<-ctx.Done()

--- a/racy_test.go
+++ b/racy_test.go
@@ -92,6 +92,14 @@ func TestNoRaces(t *testing.T) {
 	})
 
 	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, err := c.Publish("topic.a", defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c.Publish()")
+	})
+
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
 		if _, err := c2.Send(defaultMsg); err != nil && err != client.ErrNotRunning {
 			arbiter.ErrorHappened(err)
 			return
@@ -113,6 +121,14 @@ func TestNoRaces(t *testing.T) {
 			return
 		}
 		arbiter.ItsAFactThat("c2.Broadcast()")
+	})
+
+	go exec.Parallelize(ctx, wg, maxConcurrent, func() {
+		if _, err := c2.Publish("topic.a", defaultMsg); err != nil && err != client.ErrNotRunning {
+			arbiter.ErrorHappened(err)
+			return
+		}
+		arbiter.ItsAFactThat("c2.Publish()")
 	})
 
 	<-ctx.Done()


### PR DESCRIPTION

This works towards: https://github.com/eloylp/goomerang/issues/5

- Fix flaky test
- Add client broadcast execution path to the racy test
- Add pub/sub client side interfaces to racy test
- Refactor, reuse client logic in racy test
