### PR TITLE
refactor: add t.Helper() to test helper functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
           go-version: 1.19.1
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Test
         run: make cover
 
       - name: Coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cover
           path: ./cover.html

--- a/helper_test.go
+++ b/helper_test.go
@@ -79,6 +79,7 @@ func Server(t *testing.T, opts ...server.Option) (s *server.Server, run func()) 
 }
 
 func waitForServer(t *testing.T, is *server.Server) {
+	t.Helper()
 	ctx, cancl := context.WithTimeout(defaultCtx, time.Second)
 	defer cancl()
 	var serverAddr string
@@ -98,6 +99,7 @@ func waitForServer(t *testing.T, is *server.Server) {
 }
 
 func configureServer(t *testing.T, opts []server.Option) *server.Server {
+	t.Helper()
 	allOpts := []server.Option{server.WithListenAddr(kernelDefinedPort)}
 	allOpts = append(allOpts, opts...)
 	s, err := server.New(allOpts...)
@@ -117,6 +119,7 @@ func PrepareTLSServer(t *testing.T, opts ...server.Option) (s *server.Server, ru
 }
 
 func Client(t *testing.T, opts ...client.Option) (c *client.Client, connect func()) {
+	t.Helper()
 	c, err := client.New(opts...)
 	if err != nil {
 		t.Fatal(err)
@@ -131,6 +134,7 @@ func Client(t *testing.T, opts ...client.Option) (c *client.Client, connect func
 }
 
 func SelfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
 	crt, err := pki.SelfSignedCert(pki.WithCertSerialNumber(1),
 		pki.WithCertCommonName("127.0.0.1"),
 		pki.WithCertOrganization([]string{"goomerang"}),
@@ -167,6 +171,7 @@ func noErrorHook(a *test.Arbiter) func(err error) {
 }
 
 func failIfErr(t *testing.T, err error) {
+	t.Helper()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/test/arbiter.go
+++ b/internal/test/arbiter.go
@@ -54,6 +54,7 @@ func (a *Arbiter) ItsAFactThat(event string) {
 }
 
 func (a *Arbiter) RequireHappened(event string) *Arbiter {
+	a.t.Helper()
 	require.Eventuallyf(a.t, func() bool {
 		a.l.RLock()
 		defer a.l.RUnlock()
@@ -64,6 +65,7 @@ func (a *Arbiter) RequireHappened(event string) *Arbiter {
 }
 
 func (a *Arbiter) RequireNotHappened(event string) *Arbiter {
+	a.t.Helper()
 	require.Eventuallyf(a.t, func() bool {
 		a.l.RLock()
 		defer a.l.RUnlock()
@@ -74,6 +76,7 @@ func (a *Arbiter) RequireNotHappened(event string) *Arbiter {
 }
 
 func (a *Arbiter) RequireHappenedInOrder(events ...string) *Arbiter {
+	a.t.Helper()
 	passed := assert.Eventually(a.t, func() bool {
 		a.l.RLock()
 		defer a.l.RUnlock()
@@ -103,6 +106,7 @@ func (a *Arbiter) RequireHappenedInOrder(events ...string) *Arbiter {
 }
 
 func (a *Arbiter) RequireHappenedTimes(event string, expectedCount int) *Arbiter {
+	a.t.Helper()
 	var count int
 	var ok bool
 	assert.Eventuallyf(a.t, func() bool {
@@ -125,6 +129,7 @@ func (a *Arbiter) ErrorHappened(err error) {
 }
 
 func (a *Arbiter) RequireNoErrors() {
+	a.t.Helper()
 	a.l.RLock()
 	defer a.l.RUnlock()
 	var msg strings.Builder
@@ -135,6 +140,7 @@ func (a *Arbiter) RequireNoErrors() {
 }
 
 func (a *Arbiter) RequireError(errMsg string) {
+	a.t.Helper()
 	require.Eventuallyf(a.t, func() bool {
 		a.l.RLock()
 		defer a.l.RUnlock()
@@ -148,6 +154,7 @@ func (a *Arbiter) RequireError(errMsg string) {
 }
 
 func (a *Arbiter) RequireErrorIs(err error) {
+	a.t.Helper()
 	require.Eventuallyf(a.t, func() bool {
 		a.l.RLock()
 		defer a.l.RUnlock()
@@ -161,6 +168,7 @@ func (a *Arbiter) RequireErrorIs(err error) {
 }
 
 func (a *Arbiter) RequireNoEvents() {
+	a.t.Helper()
 	require.Eventuallyf(a.t, func() bool {
 		a.l.RLock()
 		defer a.l.RUnlock()


### PR DESCRIPTION
## Summary

- Add `t.Helper()` to five test helpers in `helper_test.go` (`waitForServer`, `configureServer`, `Client`, `SelfSignedCert`, `failIfErr`) that were missing it despite calling `t.Fatal`
- Add `a.t.Helper()` to all eight `Require*` methods on `Arbiter` in `internal/test/arbiter.go`
- Fix CI: update `actions/checkout@v2` and `actions/upload-artifact@v2` to v4 — these were using the Node 12 runtime that GitHub retired in 2024, causing the Test job to fail at "Set up job" before any code ran

Without `t.Helper()`, when a test fails inside one of these helpers the Go test runner reports the helper&#39;s file and line number rather than the call site in the test function. This makes failures harder to diagnose — you see the inside of `failIfErr` or `RequireHappened` instead of the test line that triggered it.

No behavior change; pure test infrastructure improvement.