### PR TITLE
refactor: drop dead var declarations and use range value in Broadcast

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -141,8 +141,6 @@ func (s *Server) Broadcast(ctx context.Context, msg *message.Message) (brResult 
 	go func() {
 		defer close(ch)
 
-		var data []byte
-		var payloadSize int
 		payloadSize, data, err := messaging.Pack(msg)
 
 		if err != nil {
@@ -159,8 +157,7 @@ func (s *Server) Broadcast(ctx context.Context, msg *message.Message) (brResult 
 
 		brResult := make([]BroadcastResult, 0, len(s.connRegistry))
 
-		for c := range s.connRegistry {
-			cs := s.connRegistry[c]
+		for _, cs := range s.connRegistry {
 			start := time.Now()
 			if err := cs.Write(data); err != nil && errCount < maxErrors {
 				errs = append(errs, fmt.Errorf("broadCast: %v", err))


### PR DESCRIPTION
Two readability issues in `server/server.go`'s `Broadcast` goroutine, fixed together since they're in the same function.

**Dead `var` declarations**

```go
// before
var data []byte
var payloadSize int
payloadSize, data, err := messaging.Pack(msg)

// after
payloadSize, data, err := messaging.Pack(msg)
```

The two `var` declarations initialize variables that are immediately overwritten by the `:=` on the very next line — they contribute nothing and add noise.

**Non-idiomatic map iteration**

```go
// before
for c := range s.connRegistry {
    cs := s.connRegistry[c]
    ...
}

// after
for _, cs := range s.connRegistry {
    ...
}
```

Ranging over a map and then re-looking up the value by key is a redundant second map access. The key `c` was never used in the loop body, so `for _, cs := range` is the correct idiomatic form.

**Changes:** `server/server.go` only. No behavior change.