### PR TITLE
refactor: store conn.Slot mutex by value, not pointer

### DIFF
--- a/conn/slot.go
+++ b/conn/slot.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Slot struct {
-	l             *sync.Mutex
+	l             sync.Mutex
 	c             *websocket.Conn
 	receivedClose chan struct{}
 }
@@ -18,7 +18,6 @@ type Slot struct {
 func NewSlot(c *websocket.Conn) *Slot {
 	return &Slot{
 		c:             c,
-		l:             &sync.Mutex{},
 		receivedClose: make(chan struct{}, 1),
 	}
 }


### PR DESCRIPTION
A pointer to `sync.Mutex` is unnecessary when the containing struct is always used via pointer — the pointer buys nothing and adds an indirection plus a heap allocation. Storing by value keeps the mutex collocated with the `Slot` in memory.

The zero value of `sync.Mutex` is an unlocked mutex, so the explicit `&sync.Mutex{}` initializer in `NewSlot` is also removed.

**Changes:** `conn/slot.go` only. No behavior change.

Same pattern fixed in #18 for `pubSubEngine`.